### PR TITLE
Adding a Errata section to PSR-7 meta

### DIFF
--- a/accepted/PSR-7-http-message-meta.md
+++ b/accepted/PSR-7-http-message-meta.md
@@ -647,3 +647,12 @@ used to populate the headers of an HTTP message.
 * Anton Serdyuk
 * Phil Sturgeon
 * Chris Wilkinson
+
+## 7 Errata
+
+### 7.1 Invalid `UriInterface` after modification (2015/09/02)
+
+Supplying a valid value to a `UriInterface` modifying method does not guarantee that the resulting `UriInterface` 
+object will generate a valid URI string. Because no exception can be thrown in a `__toString` method, the invalid 
+URI string can only be detected when the new instance is created. In such situation, a `RuntimeException` exception 
+may be thrown to indicate an invalid URI on runtime.


### PR DESCRIPTION
Adding clarification when invalid URI string are produced after modification of a UriInterface with a valid URI component/part value.